### PR TITLE
Add license to collection item.

### DIFF
--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -8,7 +8,7 @@ use crate::{Config, LegalOfficerCaseOf, pallet, PalletStorageVersion, pallet::St
 
 pub mod v9 {
 	use super::*;
-	use crate::{CollectionItemFile, CollectionItemsMap, CollectionItemOf, License, CollectionItemToken};
+	use crate::{CollectionItemFile, CollectionItemsMap, CollectionItemOf, CollectionItemToken};
 
 	#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
 	struct CollectionItemV8<Hash> {
@@ -35,7 +35,7 @@ pub mod v9 {
 							files: item.files.clone(),
 							token: item.token.clone(),
 							restricted_delivery: item.restricted_delivery.clone(),
-							license: License::None,
+							license: None,
 						};
 						Some(new_item)
 					});

--- a/src/migrations.rs
+++ b/src/migrations.rs
@@ -6,6 +6,45 @@ use frame_support::traits::OnRuntimeUpgrade;
 
 use crate::{Config, LegalOfficerCaseOf, pallet, PalletStorageVersion, pallet::StorageVersion};
 
+pub mod v9 {
+	use super::*;
+	use crate::{CollectionItemFile, CollectionItemsMap, CollectionItemOf, License, CollectionItemToken};
+
+	#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
+	struct CollectionItemV8<Hash> {
+		description: Vec<u8>,
+		files: Vec<CollectionItemFile<Hash>>,
+		token: Option<CollectionItemToken>,
+		restricted_delivery: bool,
+	}
+
+	type CollectionItemV8Of<T> = CollectionItemV8<<T as pallet::Config>::Hash>;
+
+	pub struct AddLicenseToCollectionItem<T>(sp_std::marker::PhantomData<T>);
+	impl<T: Config> OnRuntimeUpgrade for AddLicenseToCollectionItem<T> {
+
+		fn on_runtime_upgrade() -> Weight {
+			super::do_storage_upgrade::<T, _>(
+				StorageVersion::V8AddSeal,
+				StorageVersion::V9License,
+				"AddLicenseToCollectionItem",
+				|| {
+					CollectionItemsMap::<T>::translate(|_loc_id: T::LocId, _item_id: T::CollectionItemId, item: CollectionItemV8Of<T>| {
+						let new_item = CollectionItemOf::<T> {
+							description: item.description.clone(),
+							files: item.files.clone(),
+							token: item.token.clone(),
+							restricted_delivery: item.restricted_delivery.clone(),
+							license: License::None,
+						};
+						Some(new_item)
+					});
+				}
+			)
+		}
+	}
+}
+
 pub mod v8 {
 	use super::*;
 	use crate::*;
@@ -54,42 +93,6 @@ pub mod v8 {
 							seal: Option::None,
 						})
 					})
-				}
-			)
-		}
-	}
-}
-
-pub mod v7 {
-	use super::*;
-	use crate::{CollectionItemFile, CollectionItemsMap, CollectionItemOf};
-
-	#[derive(Encode, Decode, Default, Clone, PartialEq, Eq, Debug)]
-	struct CollectionItemV6<Hash> {
-		description: Vec<u8>,
-		files: Vec<CollectionItemFile<Hash>>,
-	}
-
-	type CollectionItemV6Of<T> = CollectionItemV6<<T as pallet::Config>::Hash>;
-
-	pub struct AddTokenToCollectionItem<T>(sp_std::marker::PhantomData<T>);
-	impl<T: Config> OnRuntimeUpgrade for AddTokenToCollectionItem<T> {
-
-		fn on_runtime_upgrade() -> Weight {
-			super::do_storage_upgrade::<T, _>(
-				StorageVersion::V6ItemUpload, 
-				StorageVersion::V7ItemToken, 
-				"AddTokenToCollectionItem",
-				|| {
-					CollectionItemsMap::<T>::translate(|_loc_id: T::LocId, _item_id: T::CollectionItemId, item: CollectionItemV6Of<T>| {
-						let new_item = CollectionItemOf::<T> {
-							description: item.description.clone(),
-							files: item.files.clone(),
-							token: Option::None,
-							restricted_delivery: false,
-						};
-						Some(new_item)
-					});
 				}
 			)
 		}

--- a/src/tests.rs
+++ b/src/tests.rs
@@ -5,11 +5,12 @@ use sp_runtime::traits::Hash;
 
 use logion_shared::LocQuery;
 
-use crate::{File, LegalOfficerCase, LocLink, LocType, MetadataItem, CollectionItem, CollectionItemFile, CollectionItemToken, mock::*, License, LicenseItem};
+use crate::{File, LegalOfficerCase, LocLink, LocType, MetadataItem, CollectionItem, CollectionItemFile, CollectionItemToken, mock::*, License};
 use crate::Error;
 
 const LOC_ID: u32 = 0;
 const OTHER_LOC_ID: u32 = 1;
+const LICENSE_LOC_ID: u32 = 2;
 
 #[test]
 fn it_creates_loc() {
@@ -539,52 +540,92 @@ fn it_adds_item_to_closed_collection_loc() {
 			files: vec![],
 			token: Option::None,
 			restricted_delivery: false,
-			license: License::None,
+			license: None,
 		}));
 		assert_eq!(LogionLoc::collection_size(LOC_ID), Some(1));
 	});
 }
 
 #[test]
-fn it_adds_item_with_specific_license_to_closed_collection_loc() {
+fn it_fails_to_add_licensed_item_with_non_existent_license_loc() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(LogionLoc::create_collection_loc(Origin::signed(LOC_OWNER1), LOC_ID, LOC_REQUESTER_ID, Option::None, Option::Some(10), false));
 		assert_ok!(LogionLoc::close(Origin::signed(LOC_OWNER1), LOC_ID));
 
 		let collection_item_id = BlakeTwo256::hash_of(&"item-id".as_bytes().to_vec());
 		let collection_item_description = "item-description".as_bytes().to_vec();
-		let license_hash = BlakeTwo256::hash_of(&"Specific License Content");
-		assert_ok!(LogionLoc::add_licensed_collection_item(Origin::signed(LOC_REQUESTER_ID), LOC_ID, collection_item_id, collection_item_description.clone(), vec![], Option::None, false, License::Specific(license_hash)));
-		assert_eq!(LogionLoc::collection_items(LOC_ID, collection_item_id), Some(CollectionItem {
-			description: collection_item_description,
-			files: vec![],
-			token: Option::None,
-			restricted_delivery: false,
-			license: License::Specific(license_hash),
-		}));
-		assert_eq!(LogionLoc::collection_size(LOC_ID), Some(1));
+		let license_details = "ITEM-A, ITEM-B".as_bytes().to_vec();
+		let license = License {
+			license_type: "Logion".as_bytes().to_vec(),
+			license_loc: LICENSE_LOC_ID,
+			details: license_details.clone()
+		};
+		assert_err!(LogionLoc::add_licensed_collection_item(Origin::signed(LOC_REQUESTER_ID), LOC_ID, collection_item_id, collection_item_description.clone(), vec![], Option::None, false, license.clone()), Error::<Test>::LicenseLocNotFound);
 	});
 }
 
 #[test]
-fn it_adds_item_with_logion_license_to_closed_collection_loc() {
+fn it_fails_to_add_licensed_item_with_open_license_loc() {
 	new_test_ext().execute_with(|| {
 		assert_ok!(LogionLoc::create_collection_loc(Origin::signed(LOC_OWNER1), LOC_ID, LOC_REQUESTER_ID, Option::None, Option::Some(10), false));
 		assert_ok!(LogionLoc::close(Origin::signed(LOC_OWNER1), LOC_ID));
+		assert_ok!(LogionLoc::create_polkadot_transaction_loc(Origin::signed(LOC_OWNER1), LICENSE_LOC_ID, LOC_REQUESTER_ID));
 
 		let collection_item_id = BlakeTwo256::hash_of(&"item-id".as_bytes().to_vec());
 		let collection_item_description = "item-description".as_bytes().to_vec();
-		let license_hash = BlakeTwo256::hash_of(&"Logion License Content");
-		let item1: LicenseItem = "ITEM-A".as_bytes().to_vec();
-		let item2: LicenseItem = "ITEM-B".as_bytes().to_vec();
-		let items: Vec<LicenseItem> = vec!(item1, item2);
-		assert_ok!(LogionLoc::add_licensed_collection_item(Origin::signed(LOC_REQUESTER_ID), LOC_ID, collection_item_id, collection_item_description.clone(), vec![], Option::None, false, License::Logion(license_hash, items.clone())));
+		let license_details = "ITEM-A, ITEM-B".as_bytes().to_vec();
+		let license = License {
+			license_type: "Logion".as_bytes().to_vec(),
+			license_loc: LICENSE_LOC_ID,
+			details: license_details.clone()
+		};
+		assert_err!(LogionLoc::add_licensed_collection_item(Origin::signed(LOC_REQUESTER_ID), LOC_ID, collection_item_id, collection_item_description.clone(), vec![], Option::None, false, license.clone()), Error::<Test>::LicenseLocNotClosed);
+	});
+}
+
+#[test]
+fn it_fails_to_add_licensed_item_with_void_license_loc() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(LogionLoc::create_collection_loc(Origin::signed(LOC_OWNER1), LOC_ID, LOC_REQUESTER_ID, Option::None, Option::Some(10), false));
+		assert_ok!(LogionLoc::close(Origin::signed(LOC_OWNER1), LOC_ID));
+		assert_ok!(LogionLoc::create_polkadot_transaction_loc(Origin::signed(LOC_OWNER1), LICENSE_LOC_ID, LOC_REQUESTER_ID));
+		assert_ok!(LogionLoc::make_void(Origin::signed(LOC_OWNER1), LICENSE_LOC_ID));
+
+		let collection_item_id = BlakeTwo256::hash_of(&"item-id".as_bytes().to_vec());
+		let collection_item_description = "item-description".as_bytes().to_vec();
+		let license_details = "ITEM-A, ITEM-B".as_bytes().to_vec();
+		let license = License {
+			license_type: "Logion".as_bytes().to_vec(),
+			license_loc: LICENSE_LOC_ID,
+			details: license_details.clone()
+		};
+		assert_err!(LogionLoc::add_licensed_collection_item(Origin::signed(LOC_REQUESTER_ID), LOC_ID, collection_item_id, collection_item_description.clone(), vec![], Option::None, false, license.clone()), Error::<Test>::LicenseLocVoid);
+	});
+}
+
+#[test]
+fn it_adds_item_with_license_to_closed_collection_loc() {
+	new_test_ext().execute_with(|| {
+		assert_ok!(LogionLoc::create_collection_loc(Origin::signed(LOC_OWNER1), LOC_ID, LOC_REQUESTER_ID, Option::None, Option::Some(10), false));
+		assert_ok!(LogionLoc::close(Origin::signed(LOC_OWNER1), LOC_ID));
+		assert_ok!(LogionLoc::create_polkadot_transaction_loc(Origin::signed(LOC_OWNER1), LICENSE_LOC_ID, LOC_REQUESTER_ID));
+		assert_ok!(LogionLoc::close(Origin::signed(LOC_OWNER1), LICENSE_LOC_ID));
+
+		let collection_item_id = BlakeTwo256::hash_of(&"item-id".as_bytes().to_vec());
+		let collection_item_description = "item-description".as_bytes().to_vec();
+		let license_details = "ITEM-A, ITEM-B".as_bytes().to_vec();
+		let license = License {
+			license_type: "Logion".as_bytes().to_vec(),
+			license_loc: LICENSE_LOC_ID,
+			details: license_details.clone()
+		};
+		assert_ok!(LogionLoc::add_licensed_collection_item(Origin::signed(LOC_REQUESTER_ID), LOC_ID, collection_item_id, collection_item_description.clone(), vec![], Option::None, false, license.clone()));
 		assert_eq!(LogionLoc::collection_items(LOC_ID, collection_item_id), Some(CollectionItem {
 			description: collection_item_description,
 			files: vec![],
-			token: Option::None,
+			token: None,
 			restricted_delivery: false,
-			license: License::Logion(license_hash, items.clone()),
+			license: Some(license.clone()),
 		}));
 		assert_eq!(LogionLoc::collection_size(LOC_ID), Some(1));
 	});


### PR DESCRIPTION
* An Collection Item with a **license** can be added via extrinsic `add_licensed_collection_item`.
* `license_type` and `details` are free-text.
* `licence_loc` must refer a closed non-void LOC.

logion-network/logion-internal#587